### PR TITLE
PHP <5.5 compatibility

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -342,7 +342,8 @@ class Driver extends elFinderVolumeDriver
             return $item['type'] == 'dir';
         };
         
-        return !empty(array_filter($contents, $filter));
+        $dirs = array_filter($contents, $filter);
+        return !empty($dirs);
     }
 
     /**


### PR DESCRIPTION
according to http://php.net/manual/en/function.empty.php:
Prior to PHP 5.5, empty() only supports variables
